### PR TITLE
Angular12 + more reliable validatros

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,20 +23,16 @@
   "dependencies": {
     "lodash.zip": "^4.2.0"
   },
-  "peerDependencies": {
-    "@angular/common": ">= 2.0.0",
-    "@angular/core": ">= 2.0.0",
-    "@angular/forms": ">= 2.0.0"
-  },
+  "peerDependencies": {},
   "devDependencies": {
-    "@angular/cli": "^7.0.2",
-    "@angular/common": "^7.0.0",
-    "@angular/compiler": "^7.0.0",
-    "@angular/compiler-cli": "^7.0.0",
-    "@angular/core": "^7.0.0",
-    "@angular/forms": "^7.0.0",
-    "@angular/platform-browser": "^7.0.0",
-    "@angular/platform-browser-dynamic": "^7.0.0",
+    "@angular/cli": "^12.1.1",
+    "@angular/common": "^12.1.1",
+    "@angular/compiler": "^12.1.1",
+    "@angular/compiler-cli": "^12.1.1",
+    "@angular/core": "^12.1.1",
+    "@angular/forms": "^12.1.1",
+    "@angular/platform-browser": "^12.1.1",
+    "@angular/platform-browser-dynamic": "^12.1.1",
     "@types/jasmine": "^3.3.0",
     "@types/lodash.zip": "^4.2.4",
     "@types/node": "^10.9.4",
@@ -49,9 +45,9 @@
     "rxjs": "^6.2.1",
     "rxjs-compat": "^6.2.1",
     "tslib": "^1.9.3",
-    "tslint": "^5.9.1",
-    "typescript": "^3.3.0",
-    "zone.js": "^0.8.26"
+    "tslint": "~6.1.0",
+    "typescript": "^4.0.8",
+    "zone.js": "^0.11.4"
   },
   "ngPackage": {
     "lib": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "homepage": "https://github.com/tomi77/ngx-pl-validators",
   "dependencies": {
-    "lodash.zip": "^4.2.0"
   },
   "peerDependencies": {},
   "devDependencies": {
@@ -34,7 +33,6 @@
     "@angular/platform-browser": "^12.1.1",
     "@angular/platform-browser-dynamic": "^12.1.1",
     "@types/jasmine": "^3.3.0",
-    "@types/lodash.zip": "^4.2.4",
     "@types/node": "^10.9.4",
     "codelyzer": "^4.2.1",
     "jasmine-core": "^3.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 // Module
-export { PLValidatorsModule } from "./pl-validators.module";
+export { PLValidatorsModule } from './pl-validators.module';
 
 // Directives
-export { PeselValidatorDirective } from "./pesel/pesel.directive";
+export { PeselValidatorDirective } from './pesel/pesel.directive';
 
 // Validators
-export { peselValidator } from "./pesel/pesel-validator";
+export { peselValidator } from './pesel/pesel-validator';

--- a/src/nip/nip-validator.spec.ts
+++ b/src/nip/nip-validator.spec.ts
@@ -5,26 +5,39 @@ describe('NIP validator', () => {
   it('should work for empty control', () => {
     const control: FormControl = new FormControl('');
     const validated = nipValidator(control);
-    expect(validated).toBeUndefined();
+    expect(validated).toBeNull();
+  });
+
+  it('should work for null control', () => {
+    const control: FormControl = new FormControl();
+    const validated = nipValidator(control);
+    expect(validated).toBeNull();
+  });
+
+  it('should work for undefined control', () => {
+    const control: FormControl = new FormControl();
+    const validated = nipValidator(control);
+    expect(validated).toBeNull();
   });
 
   it('should work for valid NIP', () => {
     const nips = [
-      '768-000-24-66',
-      '123-456-32-18',
-      '106-00-00-062',
-      '1234567890'
+      '7680002466',
+      '1234563218',
+      '1060000062',
+      '7742994525',
+      7742994525,
     ];
 
     nips.forEach(nip => {
       const control: FormControl = new FormControl(nip);
       const validated = nipValidator(control);
-      expect(validated).toBeUndefined();
+      expect(validated).toBeNull();
     });
   });
 
   it('should work for invalid NIP', () => {
-    const nips = ['000-000-00-00', '123-456-78-91'];
+    const nips = ['000-000-00-00', '123-456-78-91', '1231231212', '10600000620', 'abc', 123, '774-299-45-25'];
 
     nips.forEach(nip => {
       const control: FormControl = new FormControl(nip);

--- a/src/nip/nip-validator.spec.ts
+++ b/src/nip/nip-validator.spec.ts
@@ -1,19 +1,19 @@
-import { FormControl } from "@angular/forms";
-import { nipValidator } from "./nip-validator";
+import { FormControl } from '@angular/forms';
+import { nipValidator } from './nip-validator';
 
-describe("NIP validator", () => {
-  it("should work for empty control", () => {
-    const control: FormControl = new FormControl("");
+describe('NIP validator', () => {
+  it('should work for empty control', () => {
+    const control: FormControl = new FormControl('');
     const validated = nipValidator(control);
     expect(validated).toBeUndefined();
   });
 
-  it("should work for valid NIP", () => {
+  it('should work for valid NIP', () => {
     const nips = [
-      "768-000-24-66",
-      "123-456-32-18",
-      "106-00-00-062",
-      "1234567890"
+      '768-000-24-66',
+      '123-456-32-18',
+      '106-00-00-062',
+      '1234567890'
     ];
 
     nips.forEach(nip => {
@@ -23,8 +23,8 @@ describe("NIP validator", () => {
     });
   });
 
-  it("should work for invalid NIP", () => {
-    const nips = ["000-000-00-00", "123-456-78-91"];
+  it('should work for invalid NIP', () => {
+    const nips = ['000-000-00-00', '123-456-78-91'];
 
     nips.forEach(nip => {
       const control: FormControl = new FormControl(nip);

--- a/src/nip/nip-validator.ts
+++ b/src/nip/nip-validator.ts
@@ -1,6 +1,6 @@
 import { AbstractControl, ValidationErrors } from '@angular/forms';
 const WEIGHTS: number[] = [6, 5, 7, 2, 3, 4, 5, 6, 7];
-const MODULE_VALUES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
+const MODULE_VALUES: number[] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
 
 export const nipValidator: (control: AbstractControl) => ValidationErrors | null = (control: AbstractControl): ValidationErrors | null => {
   if (!control.value || control.value.length === 0) {
@@ -9,7 +9,9 @@ export const nipValidator: (control: AbstractControl) => ValidationErrors | null
   if (['0000000000'].includes(control.value)) {
     return { nip: control.value };
   }
-
+  if (control.value.length !== 10) {
+    return { nip: control.value };
+  }
   const isNipValid: boolean = checkNip(`${control.value}`);
 
   return !isNipValid ? { nip: control.value } : null;

--- a/src/nip/nip-validator.ts
+++ b/src/nip/nip-validator.ts
@@ -1,5 +1,5 @@
-import { AbstractControl } from "@angular/forms";
-import zip from "lodash.zip";
+import { AbstractControl } from '@angular/forms';
+import zip from 'lodash.zip';
 
 const WEIGHTS = [6, 5, 7, 2, 3, 4, 5, 6, 7];
 const MODULE_VALUES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
@@ -8,17 +8,17 @@ export function nipValidator(
   control: AbstractControl
 ): { [key: string]: string } {
   let value: string = control.value;
-  if (value.trim() === "") {
+  if (value.trim() === '') {
     value = null;
   }
   if (value == null) {
     return;
   }
-  value = value.replace(/[\s-]/g, "");
-  if (["0000000000"].includes(value)) {
+  value = value.replace(/[\s-]/g, '');
+  if (['0000000000'].includes(value)) {
     return { nip: control.value };
   }
-  const values: string[] = value.split("");
+  const values: string[] = value.split('');
   if (values.length !== 10) {
     return { nip: control.value };
   }
@@ -27,7 +27,7 @@ export function nipValidator(
     (memo: number, val: [string, number]) => memo + val[1] * +val[0],
     0
   );
-  value = "" + MODULE_VALUES[sum % MODULE_VALUES.length];
+  value = '' + MODULE_VALUES[sum % MODULE_VALUES.length];
   if (value !== ctrl) {
     return { nip: control.value };
   }

--- a/src/nip/nip.directive.ts
+++ b/src/nip/nip.directive.ts
@@ -1,9 +1,9 @@
-import { Directive, Input } from "@angular/core";
-import { AbstractControl, NG_VALIDATORS, Validator } from "@angular/forms";
-import { nipValidator } from "./nip-validator";
+import { Directive, Input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, Validator } from '@angular/forms';
+import { nipValidator } from './nip-validator';
 
 @Directive({
-  selector: "[nip][formControlName],[nip][formControl],[nip][ngModel]",
+  selector: '[nip][formControlName],[nip][formControl],[nip][ngModel]',
   providers: [
     {
       provide: NG_VALIDATORS,

--- a/src/pesel/pesel-validator.spec.ts
+++ b/src/pesel/pesel-validator.spec.ts
@@ -1,15 +1,15 @@
-import { FormControl } from "@angular/forms";
-import { peselValidator } from "./pesel-validator";
+import { FormControl } from '@angular/forms';
+import { peselValidator } from './pesel-validator';
 
-describe("PESEL validator", () => {
-  it("should work for empty control", () => {
-    const control: FormControl = new FormControl("");
+describe('PESEL validator', () => {
+  it('should work for empty control', () => {
+    const control: FormControl = new FormControl('');
     const validated = peselValidator(control);
     expect(validated).toBeUndefined();
   });
 
-  it("should work for valid PESEL", () => {
-    const pesels = ["49040501580", "74021834018", "74021834025", "74021834001"];
+  it('should work for valid PESEL', () => {
+    const pesels = ['49040501580', '74021834018', '74021834025', '74021834001'];
 
     pesels.forEach(pesel => {
       const control: FormControl = new FormControl(pesel);
@@ -18,8 +18,8 @@ describe("PESEL validator", () => {
     });
   });
 
-  it("should work for invalid pesel", () => {
-    const pesels = ["00000000000", "74021834012"];
+  it('should work for invalid pesel', () => {
+    const pesels = ['00000000000', '74021834012'];
 
     pesels.forEach(pesel => {
       const control: FormControl = new FormControl(pesel);

--- a/src/pesel/pesel-validator.spec.ts
+++ b/src/pesel/pesel-validator.spec.ts
@@ -5,21 +5,33 @@ describe('PESEL validator', () => {
   it('should work for empty control', () => {
     const control: FormControl = new FormControl('');
     const validated = peselValidator(control);
-    expect(validated).toBeUndefined();
+    expect(validated).toBeNull();
+  });
+
+  it('should work for null control', () => {
+    const control: FormControl = new FormControl(null);
+    const validated = peselValidator(control);
+    expect(validated).toBeNull();
+  });
+
+  it('should work for undefined control', () => {
+    const control: FormControl = new FormControl(undefined);
+    const validated = peselValidator(control);
+    expect(validated).toBeNull();
   });
 
   it('should work for valid PESEL', () => {
-    const pesels = ['49040501580', '74021834018', '74021834025', '74021834001'];
+    const pesels = ['49040501580', '74021834018', '74021834025', '74021834001', 74021834001];
 
     pesels.forEach(pesel => {
       const control: FormControl = new FormControl(pesel);
       const validated = peselValidator(control);
-      expect(validated).toBeUndefined();
+      expect(validated).toBeNull();
     });
   });
 
   it('should work for invalid pesel', () => {
-    const pesels = ['00000000000', '74021834012'];
+    const pesels = ['00000000000', '74021834012', 74021834012, 1001, 'PESEL'];
 
     pesels.forEach(pesel => {
       const control: FormControl = new FormControl(pesel);

--- a/src/pesel/pesel-validator.ts
+++ b/src/pesel/pesel-validator.ts
@@ -1,34 +1,36 @@
-import { AbstractControl } from '@angular/forms';
-import zip from 'lodash.zip';
+import { AbstractControl, ValidationErrors } from '@angular/forms';
 
-const WEIGHTS = [9, 7, 3, 1, 9, 7, 3, 1, 9, 7];
-const MODULE_VALUES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+const WEIGHTS: number[] = [9, 7, 3, 1, 9, 7, 3, 1, 9, 7];
+const MODULE_VALUES: number[] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-export function peselValidator(
-  control: AbstractControl
-): { [key: string]: string } {
-  let value: string = control.value;
-  if (value.trim() === '') {
-    value = null;
+export const peselValidator: (control: AbstractControl) => ValidationErrors | null = (control: AbstractControl):
+  ValidationErrors | null => {
+  if (!control.value || control.value.length === 0) {
+    return null;
   }
-  if (value == null) {
-    return;
+  if (['00000000000'].includes(control.value)) {
+    return {pesel: control.value};
   }
-  value = value.replace(/[\s-]/g, '');
-  if (['00000000000'].includes(value)) {
-    return { pesel: control.value };
-  }
-  const values: string[] = value.split('');
-  if (values.length !== 11) {
-    return { pesel: control.value };
-  }
-  const ctrl = values.pop();
-  const sum = zip(values, WEIGHTS).reduce(
-    (memo: number, val: [string, number]) => memo + val[1] * +val[0],
-    0
-  );
-  value = '' + MODULE_VALUES[sum % MODULE_VALUES.length];
-  if (value !== ctrl) {
-    return { pesel: control.value };
-  }
-}
+
+  return !checkPesel(`${control.value}`) ? {pesel: control.value} : null;
+};
+
+const checkPesel: (peselInput: string) => boolean = (peselInput: string): boolean => {
+  const peselDigits: number[] = peselInput.split('').map(Number);
+  const checksum: number = peselDigits.pop();
+
+  const peselReducer: (accumulator: number, currentValue: number, index: number, array: number[]) => number = (
+    accumulator: number,
+    currentValue: number,
+    index: number,
+    array: number[]
+  ): number => {
+    return accumulator + array[index] * WEIGHTS[index];
+  };
+
+  const sum: number = peselDigits.reduce(peselReducer, 0);
+
+  const peselMod11: number = MODULE_VALUES[sum % MODULE_VALUES.length];
+
+  return peselMod11 === checksum;
+};

--- a/src/pesel/pesel-validator.ts
+++ b/src/pesel/pesel-validator.ts
@@ -1,5 +1,5 @@
-import { AbstractControl } from "@angular/forms";
-import zip from "lodash.zip";
+import { AbstractControl } from '@angular/forms';
+import zip from 'lodash.zip';
 
 const WEIGHTS = [9, 7, 3, 1, 9, 7, 3, 1, 9, 7];
 const MODULE_VALUES = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -8,17 +8,17 @@ export function peselValidator(
   control: AbstractControl
 ): { [key: string]: string } {
   let value: string = control.value;
-  if (value.trim() === "") {
+  if (value.trim() === '') {
     value = null;
   }
   if (value == null) {
     return;
   }
-  value = value.replace(/[\s-]/g, "");
-  if (["00000000000"].includes(value)) {
+  value = value.replace(/[\s-]/g, '');
+  if (['00000000000'].includes(value)) {
     return { pesel: control.value };
   }
-  const values: string[] = value.split("");
+  const values: string[] = value.split('');
   if (values.length !== 11) {
     return { pesel: control.value };
   }
@@ -27,7 +27,7 @@ export function peselValidator(
     (memo: number, val: [string, number]) => memo + val[1] * +val[0],
     0
   );
-  value = "" + MODULE_VALUES[sum % MODULE_VALUES.length];
+  value = '' + MODULE_VALUES[sum % MODULE_VALUES.length];
   if (value !== ctrl) {
     return { pesel: control.value };
   }

--- a/src/pesel/pesel.directive.spec.ts
+++ b/src/pesel/pesel.directive.spec.ts
@@ -1,7 +1,7 @@
-import { PeselValidatorDirective } from "./pesel.directive";
+import { PeselValidatorDirective } from './pesel.directive';
 
-describe("PeselValidatorDirective", () => {
-  it("should create an instance", () => {
+describe('PeselValidatorDirective', () => {
+  it('should create an instance', () => {
     const directive = new PeselValidatorDirective();
     expect(directive).toBeTruthy();
   });

--- a/src/pesel/pesel.directive.ts
+++ b/src/pesel/pesel.directive.ts
@@ -1,9 +1,9 @@
-import { Directive, Input } from "@angular/core";
-import { AbstractControl, NG_VALIDATORS, Validator } from "@angular/forms";
-import { peselValidator } from "./pesel-validator";
+import { Directive, Input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, Validator } from '@angular/forms';
+import { peselValidator } from './pesel-validator';
 
 @Directive({
-  selector: "[pesel][formControlName],[pesel][formControl],[pesel][ngModel]",
+  selector: '[pesel][formControlName],[pesel][formControl],[pesel][ngModel]',
   providers: [
     {
       provide: NG_VALIDATORS,

--- a/src/pl-validators.module.ts
+++ b/src/pl-validators.module.ts
@@ -1,6 +1,6 @@
-import { NgModule } from "@angular/core";
-import { NipValidatorDirective } from "./nip/nip.directive";
-import { PeselValidatorDirective } from "./pesel/pesel.directive";
+import { NgModule } from '@angular/core';
+import { NipValidatorDirective } from './nip/nip.directive';
+import { PeselValidatorDirective } from './pesel/pesel.directive';
 
 @NgModule({
   declarations: [PeselValidatorDirective, NipValidatorDirective],

--- a/tslint.json
+++ b/tslint.json
@@ -4,17 +4,32 @@
     "codelyzer"
   ],
   "rules": {
+    "align": {
+      "options": [
+        "parameters",
+        "statements"
+      ]
+    },
     "array-type": false,
     "arrow-parens": false,
+    "arrow-return-shorthand": true,
     "deprecation": {
       "severity": "warn"
     },
+    "curly": true,
     "import-blacklist": [
       true,
       "rxjs/Rx"
     ],
     "interface-name": false,
+    "eofline": true,
     "max-classes-per-file": false,
+    "import-spacing": true,
+    "indent": {
+      "options": [
+        "spaces"
+      ]
+    },
     "max-line-length": [
       true,
       140
@@ -48,7 +63,6 @@
     "no-non-null-assertion": true,
     "no-redundant-jsdoc": true,
     "no-switch-case-fall-through": true,
-    "no-use-before-declare": true,
     "no-var-requires": false,
     "object-literal-key-quotes": [
       true,
@@ -65,11 +79,60 @@
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,
     "use-host-property-decorator": true,
+    "semicolon": {
+      "options": [
+        "always"
+      ]
+    },
+    "space-before-function-paren": {
+      "options": {
+        "anonymous": "never",
+        "asyncArrow": "always",
+        "constructor": "never",
+        "method": "never",
+        "named": "never"
+      }
+    },
     "no-input-rename": true,
+    "typedef-whitespace": {
+      "options": [
+        {
+          "call-signature": "nospace",
+          "index-signature": "nospace",
+          "parameter": "nospace",
+          "property-declaration": "nospace",
+          "variable-declaration": "nospace"
+        },
+        {
+          "call-signature": "onespace",
+          "index-signature": "onespace",
+          "parameter": "onespace",
+          "property-declaration": "onespace",
+          "variable-declaration": "onespace"
+        }
+      ]
+    },
     "no-output-rename": true,
     "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
-    "directive-class-suffix": true
+    "directive-class-suffix": true,
+    "variable-name": {
+      "options": [
+        "ban-keywords",
+        "check-format",
+        "allow-pascal-case"
+      ]
+    },
+    "whitespace": {
+      "options": [
+        "check-branch",
+        "check-decl",
+        "check-operator",
+        "check-separator",
+        "check-type",
+        "check-typecast"
+      ]
+    }
   }
 }


### PR DESCRIPTION
this version is built on version 12.1,
validator functions return correct type,
work with nullable form value,
covers more test cases.

This version not accept formatted inputs nip (xxx-xxx-xx-xx) - client application should be responsible of presenting correct format (mask). Model data should contain not formatted values.